### PR TITLE
feart: Enhances clipboard copying with MIME type selection

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 const MDN_BASE = `https://developer.mozilla.org/en-US/docs/Web/API`;
@@ -25,6 +25,67 @@ const MDN_URLS = {
 		}
 	}
 };
+
+const TEXT_COPY_MIME_OPTIONS = [
+	{ value: 'text/plain', label: 'Plain text' },
+	{ value: 'text/html', label: 'HTML' },
+	{ value: 'text/markdown', label: 'Markdown' },
+	{ value: 'text/rtf', label: 'Rich text (RTF)' },
+	{ value: 'image/svg+xml', label: 'SVG' }
+];
+
+function CopyAsMime({ text }) {
+	const [mimeType, setMimeType] = useState('text/plain');
+
+	const writeAsMime = useCallback(async () => {
+		if (!navigator.clipboard) {
+			return;
+		}
+
+		if (navigator.clipboard.write && window.ClipboardItem) {
+			try {
+				const items = {
+					'text/plain': new Blob([text], {
+						type: 'text/plain'
+					})
+				};
+
+				if (mimeType !== 'text/plain') {
+					items[mimeType] = new Blob([text], {
+						type: mimeType
+					});
+				}
+
+				await navigator.clipboard.write([new ClipboardItem(items)]);
+			} catch (error) {
+				console.warn(
+					'ClipboardItem write failed, falling back to writeText',
+					error
+				);
+			}
+		} else if (navigator.clipboard.writeText) {
+			await navigator.clipboard.writeText(text);
+		}
+	}, [mimeType, text]);
+
+	return (
+		<div className="cb-copy-as-dropdown">
+			<button type="button" onClick={writeAsMime}>
+				Copy as
+			</button>
+			<select
+				value={mimeType}
+				onChange={e => setMimeType(e.target.value)}
+			>
+				{TEXT_COPY_MIME_OPTIONS.map(option => (
+					<option key={option.value} value={option.value}>
+						{option.label}
+					</option>
+				))}
+			</select>
+		</div>
+	);
+}
 
 async function extractData(data) {
 	if (!data) {
@@ -230,22 +291,13 @@ function ClipboardInspector(props) {
 														navigator.clipboard &&
 														navigator.clipboard
 															.writeText && (
-															<div class="cb-copy">
-																<button
-																	onClick={e =>
-																		navigator.clipboard.writeText(
-																			obj.data
-																		)
-																	}
-																>
-																	Copy as
-																	plain text
-																</button>
-															</div>
+															<CopyAsMime
+																text={obj.data}
+															/>
 														)}
 												</td>
 												<td>
-													<pre class="cb-entry">
+													<pre className="cb-entry">
 														<code>
 															{typeof obj.data ===
 															'object'
@@ -326,7 +378,7 @@ function ClipboardInspector(props) {
 														<td>
 															{item.kind ===
 															'string' ? (
-																<pre class="cb-entry">
+																<pre className="cb-entry">
 																	<code>
 																		{item.as_string_or_file || (
 																			<em>

--- a/index.jsx
+++ b/index.jsx
@@ -28,10 +28,7 @@ const MDN_URLS = {
 
 const TEXT_COPY_MIME_OPTIONS = [
 	{ value: 'text/plain', label: 'Plain text' },
-	{ value: 'text/html', label: 'HTML' },
-	{ value: 'text/markdown', label: 'Markdown' },
-	{ value: 'text/rtf', label: 'Rich text (RTF)' },
-	{ value: 'image/svg+xml', label: 'SVG' }
+	{ value: 'text/html', label: 'HTML' }
 ];
 
 function CopyAsMime({ text }) {

--- a/style.css
+++ b/style.css
@@ -178,8 +178,42 @@ h1 + p {
 	margin: -0.5em 0;
 }
 
-.cb-copy {
-	padding: 0.5em 0.5em 0.5em 0;
+.cb-copy-as-dropdown {
+	margin-top: 0.75em;
+	display: inline-flex;
+	align-items: stretch;
+	border: 0.1em solid;
+	background: #f3f3f3;
+	box-shadow: 0.1em 0.1em currentColor;
+}
+
+.cb-copy-as-dropdown button {
+	appearance: none;
+	border: none;
+	background: transparent;
+	padding: 0.5em 0.75em;
+	font: inherit;
+	cursor: pointer;
+}
+
+.cb-copy-as-dropdown select {
+	border: none;
+	background: #fff;
+	padding: 0.5em 0.6em;
+	font: inherit;
+	color: inherit;
+	outline: none;
+	width: 7em;
+}
+
+.cb-copy-as-dropdown button:hover,
+.cb-copy-as-dropdown select:hover {
+	background: #fafafa;
+}
+
+.cb-copy-as-dropdown button:focus,
+.cb-copy-as-dropdown select:focus {
+	outline: 2px solid #006be4;
 }
 
 @media (max-width: 60ch) {


### PR DESCRIPTION
Introduces a new component to allow copying text content to the clipboard with various MIME types (e.g., plain text, HTML, Markdown). Useful when you want to copy a type as another type. Defaults to `plain/text`.

Utilizes the `ClipboardItem` API for rich data transfers, falling back to `writeText` for basic plain text copy if advanced features are unavailable. The UI now includes a dropdown for MIME type selection.

Updates class attributes to className for React consistency. 

<img width="432" height="179" alt="image" src="https://github.com/user-attachments/assets/24f51b7c-aebe-4ebd-8bb3-487b0620ad76" />


<img width="436" height="222" alt="image" src="https://github.com/user-attachments/assets/ea8d5d23-f3fb-49dc-9752-c042233b54b0" />
