### PR TITLE
Add Share-as-URL: encode inspection results into a static link

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,5 +1,87 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import ReactDOM from 'react-dom';
+
+// ---------- share encoding helpers ----------
+
+async function blobUrlToDataUrl(url) {
+	if (!url || typeof url !== 'string' || !url.startsWith('blob:')) return url;
+	const resp = await fetch(url);
+	const blob = await resp.blob();
+	return await new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve(reader.result);
+		reader.onerror = reject;
+		reader.readAsDataURL(blob);
+	});
+}
+
+async function inlineBlobUrls(extracted) {
+	// Walk a deep copy of extracted data, replacing blob: URLs with data: URLs
+	// so the payload can survive in a static share URL.
+	const data = JSON.parse(JSON.stringify(extracted));
+	const convertFile = async file => {
+		if (file && file.url) {
+			file.url = await blobUrlToDataUrl(file.url);
+		}
+	};
+	for (const rd of data) {
+		if (rd && rd.types) {
+			for (const t of rd.types) {
+				if (t && typeof t.data === 'object' && t.data) {
+					await convertFile(t.data);
+				}
+			}
+		}
+		if (rd && rd.items) {
+			for (const it of rd.items) {
+				if (it && it.kind !== 'string' && it.as_string_or_file) {
+					await convertFile(it.as_string_or_file);
+				}
+			}
+		}
+		if (rd && rd.files) {
+			for (const f of rd.files) await convertFile(f);
+		}
+	}
+	return data;
+}
+
+function bytesToBase64Url(bytes) {
+	let bin = '';
+	const chunk = 0x8000;
+	for (let i = 0; i < bytes.length; i += chunk) {
+		bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+	}
+	return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlToBytes(b64) {
+	let s = b64.replace(/-/g, '+').replace(/_/g, '/');
+	while (s.length % 4) s += '=';
+	const bin = atob(s);
+	const out = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+	return out;
+}
+
+async function encodeShare(extracted, label) {
+	const inlined = await inlineBlobUrls(extracted);
+	const json = JSON.stringify({ v: 1, label, data: inlined });
+	const input = new TextEncoder().encode(json);
+	const compressed = await new Response(
+		new Blob([input]).stream().pipeThrough(new CompressionStream('gzip'))
+	).arrayBuffer();
+	return bytesToBase64Url(new Uint8Array(compressed));
+}
+
+async function decodeShare(b64) {
+	const bytes = base64UrlToBytes(b64);
+	const decompressed = await new Response(
+		new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'))
+	).arrayBuffer();
+	const json = new TextDecoder().decode(decompressed);
+	return JSON.parse(json);
+}
 
 const MDN_BASE = `https://developer.mozilla.org/en-US/docs/Web/API`;
 
@@ -87,12 +169,57 @@ async function extractData(data) {
 
 function ClipboardInspector(props) {
 	const { data, label } = props;
+	const [shareUrl, setShareUrl] = useState(null);
+	const [shareError, setShareError] = useState(null);
+	const [shareBusy, setShareBusy] = useState(false);
+	const [copied, setCopied] = useState(false);
 	const has_async_clipboard =
 		!navigator.clipboard || !navigator.clipboard.read;
 	const paste = useCallback(e => {
 		navigator.clipboard.read().then(data => {
 			render(data, 'ClipboardItems');
 		});
+	}, []);
+
+	const share = useCallback(async () => {
+		setShareBusy(true);
+		setShareError(null);
+		setCopied(false);
+		try {
+			const encoded = await encodeShare(data, label);
+			const url = `${location.origin}${location.pathname}#s=${encoded}`;
+			setShareUrl(url);
+			history.replaceState(null, '', `#s=${encoded}`);
+			if (url.length > 2_000_000) {
+				setShareError(
+					`Heads up: URL is ${url.length.toLocaleString()} chars, may exceed browser limits.`
+				);
+			}
+		} catch (err) {
+			setShareError(String(err && err.message ? err.message : err));
+		} finally {
+			setShareBusy(false);
+		}
+	}, [data, label]);
+
+	const copyShareUrl = useCallback(async () => {
+		if (!shareUrl) return;
+		try {
+			await navigator.clipboard.writeText(shareUrl);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch (_) {
+			// fall through, user can copy manually
+		}
+	}, [shareUrl]);
+
+	const goBack = useCallback(() => {
+		if (location.hash) {
+			history.replaceState(null, '', location.pathname);
+		}
+		setShareUrl(null);
+		setShareError(null);
+		render();
 	}, []);
 
 	const autoselect = useCallback(e => {
@@ -174,9 +301,39 @@ function ClipboardInspector(props) {
 
 	return (
 		<div>
-			<button type="button" onClick={e => render()}>
-				← Go back
-			</button>
+			<div className="toolbar">
+				<button type="button" onClick={goBack}>
+					← Go back
+				</button>
+				<button
+					type="button"
+					onClick={share}
+					disabled={shareBusy}
+					title="Encode the inspection results into a shareable URL (no server)"
+				>
+					{shareBusy ? 'Encoding…' : '🔗 Share as URL'}
+				</button>
+				{shareUrl && (
+					<div className="share-box">
+						<div className="share-row">
+							<input
+								type="text"
+								readOnly
+								value={shareUrl}
+								onFocus={e => e.target.select()}
+							/>
+							<button type="button" onClick={copyShareUrl}>
+								{copied ? 'Copied!' : 'Copy'}
+							</button>
+						</div>
+						<div className="share-note">
+							All data is encoded directly in the URL. Nothing is
+							uploaded to any server.
+						</div>
+					</div>
+				)}
+				{shareError && <div className="share-error">{shareError}</div>}
+			</div>
 			{data.map((render_data, idx) => {
 				const URLS = MDN_URLS[render_data.type];
 				return (
@@ -384,19 +541,41 @@ function ClipboardInspector(props) {
 
 var app_el = document.getElementById('app');
 
-async function render(data, label) {
-	const extracted_data = data
-		? await Promise.all(
-				(Array.isArray(data) ? data : [data]).map(extractData)
-		  )
-		: [];
+function renderExtracted(extracted_data, label) {
 	ReactDOM.render(
 		<ClipboardInspector data={extracted_data} label={label} />,
 		app_el
 	);
 }
 
-render();
+async function render(data, label) {
+	const extracted_data = data
+		? await Promise.all(
+				(Array.isArray(data) ? data : [data]).map(extractData)
+		  )
+		: [];
+	renderExtracted(extracted_data, label);
+}
+
+async function bootstrap() {
+	const m = location.hash.match(/^#s=([A-Za-z0-9_-]+)/);
+	if (m) {
+		try {
+			const payload = await decodeShare(m[1]);
+			renderExtracted(payload.data || [], payload.label);
+			return;
+		} catch (err) {
+			console.error('Failed to decode shared clipboard data:', err);
+			app_el.textContent =
+				'Failed to decode shared clipboard data: ' +
+				(err && err.message ? err.message : err);
+			return;
+		}
+	}
+	render();
+}
+
+bootstrap();
 
 document.addEventListener('paste', e => {
 	render(e.clipboardData, 'clipboardData');

--- a/index.jsx
+++ b/index.jsx
@@ -167,12 +167,47 @@ async function extractData(data) {
 	return undefined;
 }
 
+async function buildClipboardItemFromRenderData(render_data) {
+	const map = {};
+	const addBlob = async (type, value) => {
+		if (!type || map[type]) return;
+		if (typeof value === 'string') {
+			map[type] = new Blob([value], { type });
+		} else if (value && value.url) {
+			const resp = await fetch(value.url);
+			const blob = await resp.blob();
+			map[type] = blob.type
+				? blob
+				: new Blob([await blob.arrayBuffer()], { type });
+		}
+	};
+	if (render_data.types) {
+		for (const t of render_data.types) await addBlob(t.type, t.data);
+	}
+	if (render_data.items) {
+		for (const it of render_data.items) {
+			if (it.kind === 'string') {
+				await addBlob(it.type, it.as_string_or_file);
+			} else {
+				await addBlob(it.type, it.as_string_or_file);
+			}
+		}
+	}
+	if (render_data.files) {
+		for (const f of render_data.files) {
+			if (f && f.type) await addBlob(f.type, f);
+		}
+	}
+	return map;
+}
+
 function ClipboardInspector(props) {
-	const { data, label } = props;
+	const { data, label, fromShare } = props;
 	const [shareUrl, setShareUrl] = useState(null);
 	const [shareError, setShareError] = useState(null);
 	const [shareBusy, setShareBusy] = useState(false);
 	const [copied, setCopied] = useState(false);
+	const [copyBackStatus, setCopyBackStatus] = useState({});
 	const has_async_clipboard =
 		!navigator.clipboard || !navigator.clipboard.read;
 	const paste = useCallback(e => {
@@ -201,6 +236,96 @@ function ClipboardInspector(props) {
 			setShareBusy(false);
 		}
 	}, [data, label]);
+
+	const copyBackToClipboard = useCallback(async (render_data, idx) => {
+		setCopyBackStatus(s => ({ ...s, [idx]: { busy: true } }));
+		try {
+			const map = await buildClipboardItemFromRenderData(render_data);
+			const types = Object.keys(map);
+			if (!types.length) throw new Error('No data to copy');
+			if (
+				!navigator.clipboard ||
+				!navigator.clipboard.write ||
+				typeof ClipboardItem === 'undefined'
+			) {
+				const textType =
+					types.find(t => t === 'text/plain') ||
+					types.find(t => t.startsWith('text/'));
+				if (
+					textType &&
+					navigator.clipboard &&
+					navigator.clipboard.writeText
+				) {
+					await navigator.clipboard.writeText(
+						await map[textType].text()
+					);
+					setCopyBackStatus(s => ({
+						...s,
+						[idx]: { ok: `Copied as ${textType} (fallback)` }
+					}));
+					return;
+				}
+				throw new Error('Clipboard write API unavailable');
+			}
+			try {
+				await navigator.clipboard.write([new ClipboardItem(map)]);
+				setCopyBackStatus(s => ({
+					...s,
+					[idx]: { ok: `Copied ${types.length} type(s)` }
+				}));
+			} catch (err) {
+				// Some browsers restrict allowed MIME types. Retry with a
+				// reduced set (text/plain, text/html, image/png) before
+				// falling back to plain text only.
+				const safeTypes = types.filter(t =>
+					/^(text\/(plain|html)|image\/png)$/.test(t)
+				);
+				if (safeTypes.length && safeTypes.length < types.length) {
+					const safeMap = {};
+					for (const t of safeTypes) safeMap[t] = map[t];
+					try {
+						await navigator.clipboard.write([
+							new ClipboardItem(safeMap)
+						]);
+						setCopyBackStatus(s => ({
+							...s,
+							[idx]: {
+								ok: `Copied ${
+									safeTypes.length
+								} type(s) (browser rejected: ${types
+									.filter(t => !safeTypes.includes(t))
+									.join(', ')})`
+							}
+						}));
+						return;
+					} catch (_) {
+						/* fall through */
+					}
+				}
+				const textType =
+					types.find(t => t === 'text/plain') ||
+					types.find(t => t.startsWith('text/'));
+				if (textType) {
+					await navigator.clipboard.writeText(
+						await map[textType].text()
+					);
+					setCopyBackStatus(s => ({
+						...s,
+						[idx]: {
+							ok: `Copied as ${textType} (browser rejected richer types)`
+						}
+					}));
+					return;
+				}
+				throw err;
+			}
+		} catch (err) {
+			setCopyBackStatus(s => ({
+				...s,
+				[idx]: { error: String(err && err.message ? err.message : err) }
+			}));
+		}
+	}, []);
 
 	const copyShareUrl = useCallback(async () => {
 		if (!shareUrl) return;
@@ -299,6 +424,10 @@ function ClipboardInspector(props) {
 		);
 	}
 
+	const canWriteClipboard =
+		navigator.clipboard &&
+		(navigator.clipboard.write || navigator.clipboard.writeText);
+
 	return (
 		<div>
 			<div className="toolbar">
@@ -313,6 +442,45 @@ function ClipboardInspector(props) {
 				>
 					{shareBusy ? 'Encoding…' : '🔗 Share as URL'}
 				</button>
+				{fromShare &&
+					canWriteClipboard &&
+					data.map((render_data, idx) => {
+						const cbStatus = copyBackStatus[idx] || {};
+						const multi = data.length > 1;
+						return (
+							<button
+								key={idx}
+								type="button"
+								onClick={() =>
+									copyBackToClipboard(render_data, idx)
+								}
+								disabled={cbStatus.busy}
+								title="Write all available types back to your clipboard so you can paste them elsewhere"
+							>
+								{cbStatus.busy
+									? 'Copying…'
+									: cbStatus.ok
+									? `✓ ${
+											multi
+												? `Copied #${idx + 1}`
+												: 'Copied to clipboard'
+									  }`
+									: `📋 Copy${
+											multi ? ` #${idx + 1}` : ''
+									  } to clipboard`}
+							</button>
+						);
+					})}
+				{fromShare &&
+					data.map((render_data, idx) => {
+						const cbStatus = copyBackStatus[idx] || {};
+						if (!cbStatus.error) return null;
+						return (
+							<div className="copy-back-error" key={`err-${idx}`}>
+								✗ {cbStatus.error}
+							</div>
+						);
+					})}
 				{shareUrl && (
 					<div className="share-box">
 						<div className="share-row">
@@ -541,9 +709,13 @@ function ClipboardInspector(props) {
 
 var app_el = document.getElementById('app');
 
-function renderExtracted(extracted_data, label) {
+function renderExtracted(extracted_data, label, fromShare) {
 	ReactDOM.render(
-		<ClipboardInspector data={extracted_data} label={label} />,
+		<ClipboardInspector
+			data={extracted_data}
+			label={label}
+			fromShare={!!fromShare}
+		/>,
 		app_el
 	);
 }
@@ -554,7 +726,7 @@ async function render(data, label) {
 				(Array.isArray(data) ? data : [data]).map(extractData)
 		  )
 		: [];
-	renderExtracted(extracted_data, label);
+	renderExtracted(extracted_data, label, false);
 }
 
 async function bootstrap() {
@@ -562,7 +734,7 @@ async function bootstrap() {
 	if (m) {
 		try {
 			const payload = await decodeShare(m[1]);
-			renderExtracted(payload.data || [], payload.label);
+			renderExtracted(payload.data || [], payload.label, true);
 			return;
 		} catch (err) {
 			console.error('Failed to decode shared clipboard data:', err);

--- a/style.css
+++ b/style.css
@@ -227,6 +227,12 @@ h1 + p {
 	font-size: 0.9em;
 }
 
+.copy-back-error {
+	flex: 1 1 100%;
+	color: #a00;
+	font-size: 0.9em;
+}
+
 @media (max-width: 60ch) {
 	html {
 		font-size: 90%;

--- a/style.css
+++ b/style.css
@@ -182,6 +182,51 @@ h1 + p {
 	padding: 0.5em 0.5em 0.5em 0;
 }
 
+.toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5em;
+	align-items: center;
+	margin-bottom: 1em;
+}
+
+.share-box {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em;
+	flex: 1 1 100%;
+	margin-top: 0.5em;
+}
+
+.share-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5em;
+	align-items: center;
+}
+
+.share-box input[type='text'] {
+	flex: 1 1 20em;
+	min-width: 0;
+	padding: 0.25em 0.5em;
+	border: 0.1em solid;
+	background: #fff;
+	font-family: 'Source Code Pro', Consolas, monospace;
+	font-size: 0.85em;
+}
+
+.share-note {
+	font-size: 0.85em;
+	color: #666;
+	font-style: italic;
+}
+
+.share-error {
+	flex: 1 1 100%;
+	color: #a00;
+	font-size: 0.9em;
+}
+
 @media (max-width: 60ch) {
 	html {
 		font-size: 90%;


### PR DESCRIPTION
Adds a "Share as URL" button that encodes the current inspection into a gzipped base64url payload stored in `location.hash`. Opening that URL re-renders the same inspection. No backend.

Also allows recepients to copy the shared contents back into their clipboard.

**Why:** for users that need to share raw clipboard contents when reporting clipboard-related issues to maintainers of software they use. 

**Notes**
- Uses `CompressionStream('gzip')` / `DecompressionStream` (modern browsers).
- `index.js` was intentionally left out of this PR to keep the diff readable; please `npm run build` before deploying.